### PR TITLE
Use a custom Teensy platform variant

### DIFF
--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -16,70 +16,14 @@ All Library dependencies are automatically installed using platformio.ini (lib_d
     /Synth/Firmware/src/main.cpp
 
 ## USB_MTP_MIDI - prerequisite
-### Update Platformio with the last teensyduino framework
 
-    cd ~/.platformio/packages/framework-arduinoteensy
-    rm -r cores
-    git clone https://github.com/PaulStoffregen/cores.git
+### Install our customized Teensy platform variant in PlatformIO
 
-### Create the USB_MTPDISK_MIDI inerface
-    ~/.platformio/packages/framework-arduinoteensy/cores/teensy4/usb_desc.h > ADD this deffinition
-    
-    #elif defined(USB_MTPDISK_MIDI)
-      #define VENDOR_ID		            0x16E0
-      #define PRODUCT_ID		          0x03D1
-      #define MANUFACTURER_NAME	      {'T','e','e','n','s','y','d','u','i','n','o'}
-      #define MANUFACTURER_NAME_LEN	  11
-      #define PRODUCT_NAME		        {'T','e','e','n','s','y',' ','M','T','P',' ','M','I','D','I'}
-      #define PRODUCT_NAME_LEN	      15
-      #define EP0_SIZE		            64
-      #define NUM_ENDPOINTS           5
-      #define NUM_INTERFACE           3
-      #define MTP_INTERFACE		        3   /* MTPDISK */
-      #define MTP_TX_ENDPOINT	        4
-      #define MTP_TX_SIZE_12	        64
-      #define MTP_TX_SIZE_480	        512
-      #define MTP_RX_ENDPOINT	        4
-      #define MTP_RX_SIZE_12	        64
-      #define MTP_RX_SIZE_480	        512
-      #define MTP_EVENT_ENDPOINT	    5
-      #define MTP_EVENT_SIZE	        32
-      #define MTP_EVENT_INTERVAL_12	  10
-      #define MTP_EVENT_INTERVAL_480  7
-      #define SEREMU_INTERFACE        2	  /* SERIAL_EMULATION */
-      #define SEREMU_TX_ENDPOINT      2
-      #define SEREMU_TX_SIZE          64
-      #define SEREMU_TX_INTERVAL      1
-      #define SEREMU_RX_ENDPOINT      2
-      #define SEREMU_RX_SIZE          32
-      #define SEREMU_RX_INTERVAL      2
-      #define MIDI_INTERFACE	        1	  /* MIDI */
-      #define MIDI_NUM_CABLES	        1
-      #define MIDI_TX_ENDPOINT	      3
-      #define MIDI_TX_SIZE_12	        64
-      #define MIDI_TX_SIZE_480	      512
-      #define MIDI_RX_ENDPOINT	      3
-      #define MIDI_RX_SIZE_12	        64
-      #define MIDI_RX_SIZE_480	      512
-      #define ENDPOINT2_CONFIG	      ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
-      #define ENDPOINT3_CONFIG	      ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
-      #define ENDPOINT4_CONFIG	      ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
-      #define ENDPOINT5_CONFIG	      ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
-    
-    ~/.platformio/platforms/teensy/builder/frameworks/arduino.py > ADD:
-    line 59: "USB_MTPDISK_MIDI",
-    
-    ~/.platformio/packages/framework-arduinoteensy/cores/teensy4/usb.c > ADD:
-    ligne 1031: #if defined(USB_MTPDISK) || defined(USB_MTPDISK_SERIAL) || (USB_MTPDISK_MIDI)
-    
-    ~/.pio/libdeps/teensy40/MTP_Teensy/src/MTP_Teensy.cpp > ADD:
-    ligne 28: #if defined(USB_MTPDISK) || defined(USB_MTPDISK_SERIAL) || defined(USB_MTPDISK_MIDI)
-    
-    ~/.pio/libdeps/teensy40/MTP_Teensy/src/MTP_Teensy.h > ADD:
-    line 32: #if !defined(USB_MTPDISK) && !defined(USB_MTPDISK_SERIAL) && !defined(USB_MTPDISK_MIDI)
-    
-    ~/.pio/libdeps/teensy40/MTP_Teensy/src/MTP_Teensy.h > COMMENT:
-    line 59: #include <MemoryHexDump.h>
+1. Go to "PIO Home"
+2. Click on "Platforms"
+3. Click on "Advanced Installation"
+4. Enter "https://github.com/nicolas-thill/platform-teensy-e256.git"
+5. Click "Install"
 
 ### Powering the eTextile-Synthesizer
 - The Teensy Micro USB Type B **will not power** the eTextile-Synthesizer

--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -9,23 +9,15 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:teensy40]
-platform = teensy
+platform = teensy-e256
 board = teensy40
 framework = arduino
 ;monitor_port = /dev/hidraw0
 ;monitor_speed = 230400
 lib_deps =
-    git+https://github.com/PaulStoffregen/SPI#master
-    git+https://github.com/PaulStoffregen/LittleFS#main
-    git+https://github.com/PaulStoffregen/MIDI#master
-    git+https://github.com/PaulStoffregen/Encoder#master
-    git+https://github.com/PaulStoffregen/Audio#master
-    git+https://github.com/pedvide/ADC#master
     git+https://github.com/bblanchon/ArduinoJson#v6.18.5
-    git+https://github.com/CNMAT/OSC#master
-    git+https://github.com/thomasfredericks/Bounce2#v2.60
-    git+https://github.com/PaulStoffregen/Time.git#master
-    ;git+https://github.com/KurtE/MTP_Teensy#main
+    git+https://github.com/nicolas-thill/MTP_Teensy#main
+    git+https://github.com/KurtE/MemoryHexDump#main
 build_flags =
     ;-D TEENSY_OPT_FASTEST
     ;-D USB_MTPDISK            ;Working fine


### PR DESCRIPTION
This PR wil switch to a custom Teensy PlatformIO platform with all patches applied to the differents components and providing only the required libraries:

https://github.com/nicolas-thill/platform-teensy-e256
https://github.com/nicolas-thill/framework-arduinoteensy-e256
https://github.com/nicolas-thill/cores-e256
https://github.com/nicolas-thill/MTP_Teensy-e256

These repositories will eventually move to the [eTextile](https://github.com/eTextile/) project.